### PR TITLE
404画面作成/ルーティング設定　モジュール化

### DIFF
--- a/src/app/app-routing-module.ts
+++ b/src/app/app-routing-module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { HomeComponent } from './pages/home/home.component';
+import { NotFoundComponent } from './pages/not-found/not-found.component';
+
+// ルーティング設定
+const routes: Routes = [
+  { path: '', component: HomeComponent },
+  { path: '**', component: NotFoundComponent },
+];
+
+@NgModule({
+  imports: [RouterModule.forRoot(routes)],
+  exports: [RouterModule],
+})
+export class AppRoutingModule {}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,26 +1,12 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { Routes, RouterModule } from '@angular/router';
+import { AppRoutingModule } from './app-routing-module';
 
 import { AppComponent } from './app.component';
 import { HeaderComponent } from './components/header/header.component';
 import { HomeComponent } from './pages/home/home.component';
 import { FooterComponent } from './components/footer/footer.component';
 import { NotFoundComponent } from './pages/not-found/not-found.component';
-
-// ルーティング設定
-const routes: Routes = [
-  { path: '', component: HomeComponent },
-  // {
-  //   path: 'todos',
-  //   component: TodoListComponent,
-  // },
-  // {
-  //   path: 'todo/add',
-  //   component: TodoAddComponent,
-  // },
-  { path: '**', component: NotFoundComponent },
-];
 
 @NgModule({
   declarations: [
@@ -30,7 +16,7 @@ const routes: Routes = [
     FooterComponent,
     NotFoundComponent,
   ],
-  imports: [BrowserModule, RouterModule.forRoot(routes)],
+  imports: [BrowserModule, AppRoutingModule],
   providers: [],
   bootstrap: [AppComponent],
 })

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,6 +6,7 @@ import { AppComponent } from './app.component';
 import { HeaderComponent } from './components/header/header.component';
 import { HomeComponent } from './pages/home/home.component';
 import { FooterComponent } from './components/footer/footer.component';
+import { NotFoundComponent } from './pages/not-found/not-found.component';
 
 // ルーティング設定
 const routes: Routes = [
@@ -18,11 +19,17 @@ const routes: Routes = [
   //   path: 'todo/add',
   //   component: TodoAddComponent,
   // },
-  // { path: '**', component: NotFoundComponent },
+  { path: '**', component: NotFoundComponent },
 ];
 
 @NgModule({
-  declarations: [AppComponent, HeaderComponent, HomeComponent, FooterComponent],
+  declarations: [
+    AppComponent,
+    HeaderComponent,
+    HomeComponent,
+    FooterComponent,
+    NotFoundComponent,
+  ],
   imports: [BrowserModule, RouterModule.forRoot(routes)],
   providers: [],
   bootstrap: [AppComponent],

--- a/src/app/pages/not-found/not-found.component.html
+++ b/src/app/pages/not-found/not-found.component.html
@@ -1,0 +1,17 @@
+<div class="flex justify-center items-center h-screen">
+  <div class="bg-white p-6 md:p-12 shadow-lg rounded-lg">
+    <h1 class="text-gray-800 text-3xl md:text-4xl font-bold mb-4">
+      404: Not Found
+    </h1>
+    <p class="text-gray-600 mb-8">
+      アクセスしようとしたページは見つかりませんでした。
+      ページのURLが変更されている場合があります。
+    </p>
+    <button
+      class="bg-blue-500 hover:opacity-80 text-white font-bold py-3 px-4 rounded"
+      [routerLink]="['/']"
+    >
+      トップページに戻る
+    </button>
+  </div>
+</div>

--- a/src/app/pages/not-found/not-found.component.html
+++ b/src/app/pages/not-found/not-found.component.html
@@ -1,4 +1,4 @@
-<div class="flex justify-center items-center h-screen">
+<div class="flex justify-center items-center h-full">
   <div class="bg-white p-6 md:p-12 shadow-lg rounded-lg">
     <h1 class="text-gray-800 text-3xl md:text-4xl font-bold mb-4">
       404: Not Found

--- a/src/app/pages/not-found/not-found.component.spec.ts
+++ b/src/app/pages/not-found/not-found.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NotFoundComponent } from './not-found.component';
+
+describe('NotFoundComponent', () => {
+  let component: NotFoundComponent;
+  let fixture: ComponentFixture<NotFoundComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ NotFoundComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NotFoundComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/not-found/not-found.component.ts
+++ b/src/app/pages/not-found/not-found.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-not-found',
+  templateUrl: './not-found.component.html',
+  styleUrls: ['./not-found.component.scss']
+})
+export class NotFoundComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}


### PR DESCRIPTION
# この PR の目的

404画面作成/ルーティング設定　モジュール化

# やったこと

- 404画面作成
- ルーティング処理を`app.module`から別ファイルに切り出し(モジュール化) AppRoutingModule


# UI before after
![スクリーンショット 2024-05-06 16 09 44](https://github.com/m-shimizu-f-50/angular-app-13/assets/62657297/5b63874f-25a1-467a-ab86-a5237348f1be)

